### PR TITLE
Allow upsmon client type to be configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ nut_client_ups: nut-server
 nut_client_server: 127.0.0.1
 nut_client_username: observer
 nut_client_password: password_here
+nut_client_type: secondary
 ```
 
 Controls the `nut-client` primary server access options.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,6 +3,7 @@ nut_client_ups: nut-server
 nut_client_server: 127.0.0.1
 nut_client_username: observer
 nut_client_password: password_here
+nut_client_type: secondary
 
 nut_client_state: started
 nut_client_enabled: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,7 +8,7 @@
   lineinfile:
     path: /etc/nut/upsmon.conf
     regexp: "^MONITOR.*"
-    line: "MONITOR {{ nut_client_ups }}@{{ nut_client_server }} 1 {{ nut_client_username }} {{ nut_client_password }} secondary"
+    line: "MONITOR {{ nut_client_ups }}@{{ nut_client_server }} 1 {{ nut_client_username }} {{ nut_client_password }} {{ nut_client_type | default('secondary') }}"
     state: present
     mode: 0640
   notify: restart nut-client


### PR DESCRIPTION
I have an older version of nut on an appliance where I can't easily upgrade. Adding a `nut_client_type` option to allow for `secondary` (default), or `slave` (legacy) to be used.